### PR TITLE
Add podspec

### DIFF
--- a/Layout.podspec
+++ b/Layout.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name                  = 'Layout'
   s.version               = '0.0.0'
   s.summary               = 'Tinder\'s UIKit Auto Layout API'
-  s.description           = 'API for adding subviews and constraints to a view.'
+  s.description           = 'An API for adding subviews and constraints to a view.'
   s.homepage              = 'https://github.com/Tinder/Layout'
   s.license               = ''
   s.author                = { 'Tinder' => 'info@gotinder.com' }


### PR DESCRIPTION
Adds `Layout.podspec` to support installation via CocoaPods.

Results for `pod lib lint Layout.podspec --skip-tests`

```
 -> Layout (0.0.0)
    - WARN  | license: Invalid license type.
    - NOTE  | url: The URL (https://github.com/Tinder/Layout) is not reachable.
    - WARN  | [iOS] license: Unable to find a license file
    - NOTE  | xcodebuild:  note: Using codesigning identity override: -
    - NOTE  | [iOS] xcodebuild:  note: Building targets in dependency order
    - NOTE  | [iOS] xcodebuild:  note: Metadata extraction skipped. No AppIntents.framework dependency found. (in target 'Layout' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  note: Metadata extraction skipped. No AppIntents.framework dependency found. (in target 'App' from project 'App')
```

You can test these changes via:

1. Create an Xcode project
2. Run `pod init`
3. Add this to your podfile: `pod 'Layout', :path => '/Path/To/Local/Layout', :testspecs => ['Tests']`