### PR TITLE
Remove unneeded import in XAxisAttribute.swift

### DIFF
--- a/Sources/Layout/XAxisAttribute.swift
+++ b/Sources/Layout/XAxisAttribute.swift
@@ -7,8 +7,6 @@
 //  See https://github.com/Tinder/Layout/blob/main/LICENSE for license information.
 //
 
-import Foundation
-
 public enum XAxisAttribute {
 
     case left, centerX, right, leading, trailing


### PR DESCRIPTION
Remove unneeded import in XAxisAttribute.swift