### PR TITLE
Add missing default param test

### DIFF
--- a/Tests/LayoutTests/LayoutTests.swift
+++ b/Tests/LayoutTests/LayoutTests.swift
@@ -573,6 +573,7 @@ final class LayoutTests: XCTestCase {
 
             // Anchor With Constant
 
+            layout.constrain(pinkView.height, is: .greaterThanOrEqual, to: 150, priority: .high)
             layout.constrain(pinkView.height, to: 100)
 
             // Anchor with Greater Than Or Equal Relation, Constant and Priority


### PR DESCRIPTION
Add an additional snapshot test that was missed when [this PR](https://github.com/Tinder/Layout/pull/240) was made. The additional test covers the default priority and relation parameters of `Layout`'s `constrain(_ anchor: is: to: priority:)` method.