### PR TITLE
Remove unneeded vfl helper methods

### DIFF
--- a/Sources/Layout/Layout.swift
+++ b/Sources/Layout/Layout.swift
@@ -86,7 +86,10 @@ public final class Layout { // swiftlint:disable:this type_body_length
         metrics: [String: Any]? = nil,
         options: NSLayoutConstraint.FormatOptions = []
     ) -> Layout {
-        vfl(axis: .vertical, format: format, metrics: metrics, options: options)
+        adding(NSLayoutConstraint.constraints(format: "V:" + format,
+                                              views: items,
+                                              metrics: metrics ?? self.metrics,
+                                              options: options))
     }
 
     @discardableResult
@@ -95,24 +98,7 @@ public final class Layout { // swiftlint:disable:this type_body_length
         metrics: [String: Any]? = nil,
         options: NSLayoutConstraint.FormatOptions = []
     ) -> Layout {
-        vfl(axis: .horizontal, format: format, metrics: metrics, options: options)
-    }
-
-    private func vfl(
-        axis: NSLayoutConstraint.Axis,
-        format: String,
-        metrics: [String: Any]? = nil,
-        options: NSLayoutConstraint.FormatOptions = []
-    ) -> Layout {
-        vfl(axis.orientation + ":" + format, metrics: metrics, options: options)
-    }
-
-    private func vfl(
-        _ format: String,
-        metrics: [String: Any]? = nil,
-        options: NSLayoutConstraint.FormatOptions = []
-    ) -> Layout {
-        adding(NSLayoutConstraint.constraints(format: format,
+        adding(NSLayoutConstraint.constraints(format: "H:" + format,
                                               views: items,
                                               metrics: metrics ?? self.metrics,
                                               options: options))

--- a/Sources/Layout/UIKit/NSLayoutConstraint-Axis.swift
+++ b/Sources/Layout/UIKit/NSLayoutConstraint-Axis.swift
@@ -12,17 +12,6 @@ import UIKit
 
 extension NSLayoutConstraint.Axis {
 
-    internal var orientation: String {
-        switch self {
-        case .horizontal:
-            return "H"
-        case .vertical:
-            return "V"
-        @unknown default:
-            return "H"
-        }
-    }
-
     internal var attribute: NSLayoutConstraint.Attribute {
         switch self {
         case .horizontal:

--- a/Tests/LayoutTests/UIKit/NSLayoutConstraint-AxisTests.swift
+++ b/Tests/LayoutTests/UIKit/NSLayoutConstraint-AxisTests.swift
@@ -15,19 +15,6 @@ import XCTest
 @MainActor
 final class NSLayoutConstraintAxisTests: XCTestCase {
 
-    func testOrientation() {
-
-        // GIVEN
-
-        let horizontalAxis: NSLayoutConstraint.Axis = .horizontal
-        let verticalAxis: NSLayoutConstraint.Axis = .vertical
-
-        // THEN
-
-        expect(horizontalAxis.orientation) == "H"
-        expect(verticalAxis.orientation) == "V"
-    }
-
     func testAttribute() {
 
         // GIVEN


### PR DESCRIPTION
This PR does the following:

* Remove unneeded vfl helper methods
    * `vfl(axis:, format:, metrics:, options:) -> Layout`
    * `vfl(format:, metrics:, options:) -> Layout`
* Removes `orientation` property from `NSLayoutConstraint.Axis` as it is no longer used after helper methods removal.