### PR TITLE
Set Layout properties in order of definition

### DIFF
--- a/Sources/Layout/Layout.swift
+++ b/Sources/Layout/Layout.swift
@@ -135,10 +135,10 @@ public final class Layout { // swiftlint:disable:this type_body_length
             if subview.superview != view {
                 view?.addSubview(subview)
             }
-            adding(item.superviewConstraints(item))
             if let key: String = subview.identifier, !key.isEmpty {
                 self.items[key] = subview
             }
+            adding(item.superviewConstraints(item))
         }
         return self
     }


### PR DESCRIPTION
The layout properties are defined in this order:
```swift
var items: [String: LayoutItem] = [:]
var constraints: [NSLayoutConstraint] = []
```
So within the `addItems()` method, we now set `items` before `constraints`.